### PR TITLE
Upgrade the unikernel to git.3.1.0

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -1,32 +1,158 @@
-(* (c) 2017, 2018 Hannes Mehnert, all rights reserved *)
-
 open Mirage
+
+type mimic = Mimic
+
+let mimic = typ Mimic
+
+let mimic_count =
+  let v = ref (-1) in
+  fun () -> incr v ; !v
+
+let mimic_conf () =
+  let packages = [ package "mimic" ] in
+  impl @@ object
+       inherit base_configurable
+       method ty = mimic @-> mimic @-> mimic
+       method module_name = "Mimic.Merge"
+       method! packages = Key.pure packages
+       method name = Fmt.str "merge_ctx%02d" (mimic_count ())
+       method! connect _ _modname =
+         function
+         | [ a; b ] -> Fmt.str "Lwt.return (Mimic.merge %s %s)" a b
+         | [ x ] -> Fmt.str "%s.ctx" x
+         | _ -> Fmt.str "Lwt.return Mimic.empty"
+     end
+
+let merge ctx0 ctx1 = mimic_conf () $ ctx0 $ ctx1
+
+let mimic_tcp_conf =
+  let packages = [ package "git-mirage" ~sublibs:[ "tcp" ] ] in
+  impl @@ object
+       inherit base_configurable
+       method ty = stackv4 @-> mimic
+       method module_name = "Git_mirage_tcp.Make"
+       method! packages = Key.pure packages
+       method name = "tcp_ctx"
+       method! connect _ modname = function
+         | [ stack ] ->
+           Fmt.str {ocaml|Lwt.return (%s.with_stack %s %s.ctx)|ocaml}
+             modname stack modname
+         | _ -> assert false
+     end
+
+let mimic_tcp_impl stackv4 = mimic_tcp_conf $ stackv4
+
+let mimic_ssh_conf ~kind ~seed ~auth =
+  let seed = Key.abstract seed in
+  let auth = Key.abstract auth in
+  let packages = [ package "git-mirage" ~sublibs:[ "ssh" ] ] in
+  impl @@ object
+       inherit base_configurable
+       method ty = stackv4 @-> mimic @-> mclock @-> mimic
+       method! keys = [ seed; auth; ]
+       method module_name = "Git_mirage_ssh.Make"
+       method! packages = Key.pure packages
+       method name = match kind with
+         | `Rsa -> "ssh_rsa_ctx"
+         | `Ed25519 -> "ssh_ed25519_ctx"
+       method! connect _ modname =
+         function
+         | [ _; tcp_ctx; _ ] ->
+             let with_key =
+               match kind with
+               | `Rsa -> "with_rsa_key"
+               | `Ed25519 -> "with_ed25519_key"
+             in
+             Fmt.str
+               {ocaml|let ssh_ctx00 = Mimic.merge %s %s.ctx in
+                      let ssh_ctx01 = Option.fold ~none:ssh_ctx00 ~some:(fun v -> %s.%s v ssh_ctx00) %a in
+                      let ssh_ctx02 = Option.fold ~none:ssh_ctx01 ~some:(fun v -> %s.with_authenticator v ssh_ctx01) %a in
+                      Lwt.return ssh_ctx02|ocaml}
+               tcp_ctx modname
+               modname with_key Key.serialize_call seed
+               modname Key.serialize_call auth
+         | _ -> assert false
+     end
+
+let mimic_ssh_impl ~kind ~seed ~auth stackv4 mimic_git mclock =
+  mimic_ssh_conf ~kind ~seed ~auth
+  $ stackv4
+  $ mimic_git
+  $ mclock
+
+(* TODO(dinosaure): user-defined nameserver and port. *)
+
+let mimic_dns_conf =
+  let packages = [ package "git-mirage" ~sublibs:[ "dns" ] ] in
+  impl @@ object
+       inherit base_configurable
+       method ty = random @-> mclock @-> time @-> stackv4 @-> mimic @-> mimic
+       method module_name = "Git_mirage_dns.Make"
+       method! packages = Key.pure packages
+       method name = "dns_ctx"
+       method! connect _ modname =
+         function
+         | [ _; _; _; stack; tcp_ctx ] ->
+             Fmt.str
+               {ocaml|let dns_ctx00 = Mimic.merge %s %s.ctx in
+                      let dns_ctx01 = %s.with_dns %s dns_ctx00 in
+                      Lwt.return dns_ctx01|ocaml}
+               tcp_ctx modname
+               modname stack
+         | _ -> assert false
+     end
+
+let mimic_dns_impl random mclock time stackv4 mimic_tcp =
+  mimic_dns_conf $ random $ mclock $ time $ stackv4 $ mimic_tcp
+
+(* / *)
 
 let remote_k =
   let doc = Key.Arg.info ~doc:"Remote git repository." ["r"; "remote"] in
-  Key.(create "remote" Arg.(opt string "https://github.com/roburio/udns.git" doc))
+  Key.(create "remote" Arg.(opt string "git@localhost:mirage/zone" doc))
 
 let axfr =
   let doc = Key.Arg.info ~doc:"Allow unauthenticated zone transfer." ["axfr"] in
   Key.(create "axfr" Arg.(flag doc))
+
+let ssh_seed =
+  let doc = Key.Arg.info ~doc:"Seed of the private SSH key." [ "ssh-seed" ] in
+  Key.(create "ssh_seed" Arg.(opt (some string) None doc))
+
+let ssh_auth =
+  let doc = Key.Arg.info ~doc:"SSH public key of the remote Git endpoint." [ "ssh-auth" ] in
+  Key.(create "ssh_auth" Arg.(opt (some string) None doc))
 
 let dns_handler =
   let packages = [
     package "logs" ;
     package ~min:"4.3.0" ~sublibs:["mirage"; "zone"] "dns-server";
     package "dns-tsig";
-    package ~min:"2.0.0" "irmin-mirage";
-    package ~min:"2.0.0" "irmin-mirage-git";
+    package ~min:"2.5.1" "irmin-mirage";
+    package ~min:"2.5.1" "irmin-mirage-git";
+    package ~min:"3.3.0" "git";
     package "conduit-mirage";
   ] in
   foreign
     ~keys:[Key.abstract remote_k ; Key.abstract axfr]
     ~packages
     "Unikernel.Main"
-    (random @-> pclock @-> mclock @-> time @-> stackv4 @-> resolver @-> conduit @-> job)
+    (random @-> pclock @-> mclock @-> time @-> stackv4 @-> resolver @-> conduit @-> mimic @-> job)
+
+let mimic ~kind ~seed ~auth stackv4 random mclock time =
+  let mtcp = mimic_tcp_impl stackv4 in
+  let mdns = mimic_dns_impl random mclock time stackv4 mtcp in
+  let mssh = mimic_ssh_impl ~kind ~seed ~auth stackv4 mtcp mclock in
+  merge mssh mdns
 
 let () =
   let net = generic_stackv4 default_network in
+  let random = default_random in
+  let pclock = default_posix_clock in
+  let mclock = default_monotonic_clock in
+  let time = default_time in
+  let conduit = conduit_direct ~tls:true net in
+  let resolver = resolver_dns ~random ~time ~mclock net in
+  let mimic = mimic ~kind:`Rsa ~seed:ssh_seed ~auth:ssh_auth net random mclock time in
   register "primary-git"
-    [dns_handler $ default_random $ default_posix_clock $ default_monotonic_clock $
-     default_time $ net $ resolver_dns net $ conduit_direct ~tls:true net]
+    [ dns_handler $ random $ pclock $ mclock $ time $ net $ resolver $ conduit $ mimic ]

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -4,15 +4,15 @@
 
 open Lwt.Infix
 
-module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) = struct
+module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) (_ : Resolver_lwt.S) (_ : Conduit_mirage.S) (_ : sig end) = struct
 
   module Store = Irmin_mirage_git.Mem.KV(Irmin.Contents.String)
   module Sync = Irmin.Sync(Store)
 
-  let connect_store resolver conduit =
+  let connect_store ctx =
     let config = Irmin_mem.config () in
     Store.Repo.v config >>= Store.master >|= fun repo ->
-    repo, Store.remote ~conduit ~resolver (Key_gen.remote ())
+    repo, Store.remote ~ctx (Key_gen.remote ())
 
   let pull_store repo upstream =
     Logs.info (fun m -> m "pulling from remote!");
@@ -28,10 +28,10 @@ module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MC
     Lwt_list.fold_left_s (fun acc (name, kind) ->
         match acc with
         | Error e -> Lwt.return (Error e)
-        | Ok acc -> match kind, Domain_name.of_string name with
-          | `Node, _ -> Lwt.return (Error (name, "got node, expected contents"))
-          | `Contents, Error (`Msg e) -> Lwt.return (Error (name, "not a domain name " ^ e))
-          | `Contents, Ok zone ->
+        | Ok acc -> match Store.Tree.destruct kind, Domain_name.of_string name with
+          | `Node _, _ -> Lwt.return (Error (name, "got node, expected contents"))
+          | `Contents _, Error (`Msg e) -> Lwt.return (Error (name, "not a domain name " ^ e))
+          | `Contents _, Ok zone ->
             Store.get store [name] >|= fun data ->
             Ok ((zone, data) :: acc))
       (Ok []) files
@@ -206,8 +206,11 @@ module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MC
 
   module D = Dns_server_mirage.Make(P)(M)(T)(S)
 
-  let start _rng _pclock _mclock _time s resolver conduit =
-    connect_store resolver conduit >>= fun (store, upstream) ->
+  let start _rng _pclock _mclock _time s resolver conduit ctx =
+    let ctx = Git_cohttp_mirage.with_conduit (Cohttp_mirage.Client.ctx resolver conduit) ctx in
+    (* XXX(dinosaure): we must add the given [conduit] into [ctx] to be able to start
+     * a TLS connection. *)
+    connect_store ctx >>= fun (store, upstream) ->
     Logs.info (fun m -> m "i have now master!");
     load_git None store upstream >>= function
     | Error (`Msg msg) ->
@@ -215,7 +218,7 @@ module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MC
       Lwt.return_unit
     | Ok (trie, keys) ->
       let on_update ~old ~authenticated_key ~update_source t =
-        store_zones ~old authenticated_key update_source t store upstream
+        store_zones ~old authenticated_key update_source t store (Store.remote ~ctx (Key_gen.remote ()))
       and on_notify n t =
         match n with
         | `Notify soa ->


### PR DESCRIPTION
This PR needs ocaml/opam-repository#17966 (or `git.3.1.0`). It updates:
- the `config.ml` and import `mimic`'s stuffs 
  this part is a bit cryptic. The idea is to _fill_ a `Mimic.ctx` according to user's arguments (such as `ssh-seed`, `ssh-auth` and `remote`). This way to play with `mimic` is done without any DNS resolvers - even if we are able to add one (or add a `Mimic.fold : [ host ] Domain_name.t -> Ipaddr.V4.t`). With that, we are able to be synchronize to a local Git repository (`git://`, `git@...`, `http://`).
- An upgrade to `irmin.2.3.0` which shadows `Store.tree`

Some notes:
- [ ] we don't support IPv6 yet but if the server can use it, I can upgrade the rest to IPv6 easily
- [x] `https` is not available due to the remove of `conduit`/`resolver` - in such context and specifically for this unikernel, we should not have a DNS resolver which is needed for `https` in anyway
- [x] remove `mimic_conf` which is not used (it's a merge operation from 2 `Mimic.ctx` with `functoria`)

If you have any question, let me know :+1:. I can go deeper about details (and `mimic`).