### PR TITLE
Upgrade config.ml with MirageOS 4

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -8,103 +8,62 @@ type mimic = Mimic
 
 let mimic = typ Mimic
 
-let mimic_count =
-  let v = ref (-1) in
-  fun () -> incr v ; !v
-
-let mimic_conf () =
+let mimic_conf =
   let packages = [ package "mimic" ] in
-  impl @@ object
-       inherit base_configurable
-       method ty = mimic @-> mimic @-> mimic
-       method module_name = "Mimic.Merge"
-       method! packages = Key.pure packages
-       method name = Fmt.str "merge_ctx%02d" (mimic_count ())
-       method! connect _ _modname =
-         function
-         | [ a; b ] -> Fmt.str "Lwt.return (Mimic.merge %s %s)" a b
-         | [ x ] -> Fmt.str "%s.ctx" x
-         | _ -> Fmt.str "Lwt.return Mimic.empty"
-     end
+  let connect _ _modname = function
+    | [ a; b ] -> Fmt.str "Lwt.return (Mimic.merge %s %s)" a b
+    | [ x ] -> Fmt.str "%s.ctx" x
+    | _ -> Fmt.str "Lwt.return Mimic.empty" in
+  impl ~packages ~connect "Mimic.Merge" (mimic @-> mimic @-> mimic)
 
-let merge ctx0 ctx1 = mimic_conf () $ ctx0 $ ctx1
+let merge ctx0 ctx1 = mimic_conf $ ctx0 $ ctx1
 
 let mimic_tcp_conf =
   let packages = [ package "git-mirage" ~sublibs:[ "tcp" ] ] in
-  impl @@ object
-       inherit base_configurable
-       method ty = stackv4v6 @-> mimic
-       method module_name = "Git_mirage_tcp.Make"
-       method! packages = Key.pure packages
-       method name = "tcp_ctx"
-       method! connect _ modname = function
-         | [ stack ] ->
-           Fmt.str {ocaml|Lwt.return (%s.with_stack %s %s.ctx)|ocaml}
-             modname stack modname
-         | _ -> assert false
-     end
+  let connect _ modname = function
+    | [ stack ] ->
+      Fmt.str {ocaml|Lwt.return (%s.with_stack %s %s.ctx)|ocaml}
+        modname stack modname
+    | _ -> assert false in
+  impl ~packages ~connect "Git_mirage_tcp.Make" (stackv4v6 @-> mimic)
 
 let mimic_tcp_impl stackv4v6 = mimic_tcp_conf $ stackv4v6
 
 let mimic_ssh_conf ~kind ~seed ~auth =
-  let seed = Key.abstract seed in
-  let auth = Key.abstract auth in
+  let seed = Key.v seed in
+  let auth = Key.v auth in
   let packages = [ package "git-mirage" ~sublibs:[ "ssh" ] ] in
-  impl @@ object
-       inherit base_configurable
-       method ty = stackv4v6 @-> mimic @-> mclock @-> mimic
-       method! keys = [ seed; auth; ]
-       method module_name = "Git_mirage_ssh.Make"
-       method! packages = Key.pure packages
-       method name = match kind with
-         | `Rsa -> "ssh_rsa_ctx"
-         | `Ed25519 -> "ssh_ed25519_ctx"
-       method! connect _ modname =
-         function
-         | [ _; tcp_ctx; _ ] ->
-             let with_key =
-               match kind with
-               | `Rsa -> "with_rsa_key"
-               | `Ed25519 -> "with_ed25519_key"
-             in
-             Fmt.str
-               {ocaml|let ssh_ctx00 = Mimic.merge %s %s.ctx in
-                      let ssh_ctx01 = Option.fold ~none:ssh_ctx00 ~some:(fun v -> %s.%s v ssh_ctx00) %a in
-                      let ssh_ctx02 = Option.fold ~none:ssh_ctx01 ~some:(fun v -> %s.with_authenticator v ssh_ctx01) %a in
-                      Lwt.return ssh_ctx02|ocaml}
-               tcp_ctx modname
-               modname with_key Key.serialize_call seed
-               modname Key.serialize_call auth
-         | _ -> assert false
-     end
+  let connect _ modname = function
+    | [ _; tcp_ctx; _ ] ->
+        let with_key = match kind with
+          | `Rsa -> "with_rsa_key"
+          | `Ed25519 -> "with_ed25519_key" in
+        Fmt.str
+          {ocaml|let ssh_ctx00 = Mimic.merge %s %s.ctx in
+                 let ssh_ctx01 = Option.fold ~none:ssh_ctx00 ~some:(fun v -> %s.%s v ssh_ctx00) %a in
+                 let ssh_ctx02 = Option.fold ~none:ssh_ctx01 ~some:(fun v -> %s.with_authenticator v ssh_ctx01) %a in
+                 Lwt.return ssh_ctx02|ocaml}
+          tcp_ctx modname
+          modname with_key Key.serialize_call seed
+          modname Key.serialize_call auth
+    | _ -> assert false in
+  impl ~packages ~connect ~keys:[ seed; auth; ] "Git_mirage_ssh.Make" (stackv4v6 @-> mimic @-> mclock @-> mimic)
 
 let mimic_ssh_impl ~kind ~seed ~auth stackv4v6 mimic_git mclock =
-  mimic_ssh_conf ~kind ~seed ~auth
-  $ stackv4v6
-  $ mimic_git
-  $ mclock
-
-(* TODO(dinosaure): user-defined nameserver and port. *)
+  mimic_ssh_conf ~kind ~seed ~auth $ stackv4v6 $ mimic_git $ mclock
 
 let mimic_dns_conf =
   let packages = [ package "git-mirage" ~sublibs:[ "dns" ] ] in
-  impl @@ object
-       inherit base_configurable
-       method ty = random @-> mclock @-> time @-> stackv4v6 @-> mimic @-> mimic
-       method module_name = "Git_mirage_dns.Make"
-       method! packages = Key.pure packages
-       method name = "dns_ctx"
-       method! connect _ modname =
-         function
-         | [ _; _; _; stack; tcp_ctx ] ->
-             Fmt.str
-               {ocaml|let dns_ctx00 = Mimic.merge %s %s.ctx in
-                      let dns_ctx01 = %s.with_dns %s dns_ctx00 in
-                      Lwt.return dns_ctx01|ocaml}
-               tcp_ctx modname
-               modname stack
-         | _ -> assert false
-     end
+  let connect _ modname = function
+    | [ _; _; _; stack; tcp_ctx ] ->
+        Fmt.str
+          {ocaml|let dns_ctx00 = Mimic.merge %s %s.ctx in
+                 let dns_ctx01 = %s.with_dns %s dns_ctx00 in
+                 Lwt.return dns_ctx01|ocaml}
+          tcp_ctx modname
+          modname stack
+    | _ -> assert false in
+  impl ~packages ~connect "Git_mirage_dns.Make" (random @-> mclock @-> time @-> stackv4v6 @-> mimic @-> mimic)
 
 let mimic_dns_impl random mclock time stackv4v6 mimic_tcp =
   mimic_dns_conf $ random $ mclock $ time $ stackv4v6 $ mimic_tcp
@@ -114,32 +73,20 @@ let paf = typ Paf
 
 let paf_conf () =
   let packages = [ package "paf" ~sublibs:[ "mirage" ] ] in
-  impl @@ object
-    inherit base_configurable
-    method ty = time @-> stackv4v6 @-> paf
-    method module_name = "Paf_mirage.Make"
-    method! packages = Key.pure packages
-    method name = "paf"
-  end
+  impl ~packages "Paf_mirage.Make" (time @-> stackv4v6 @-> paf)
 
 let paf_impl time stackv4v6 = paf_conf () $ time $ stackv4v6
 
 let mimic_paf_conf () =
   let packages = [ package "git-paf" ] in
-  impl @@ object
-       inherit base_configurable
-       method ty = time @-> pclock @-> stackv4v6 @-> paf @-> mimic @-> mimic
-       method module_name = "Git_paf.Make"
-       method! packages = Key.pure packages
-       method name = "paf_ctx"
-       method! connect _ modname = function
-         | [ _; _; _; _; tcp_ctx; ] ->
-             Fmt.str
-               {ocaml|let paf_ctx00 = Mimic.merge %s %s.ctx in
-                      Lwt.return paf_ctx00|ocaml}
-               tcp_ctx modname
-         | _ -> assert false
-     end
+  let connect _ modname = function
+    | [ _; _; _; _; tcp_ctx; ] ->
+        Fmt.str
+          {ocaml|let paf_ctx00 = Mimic.merge %s %s.ctx in
+                 Lwt.return paf_ctx00|ocaml}
+          tcp_ctx modname
+    | _ -> assert false in
+  impl ~packages ~connect "Git_paf.Make" (time @-> pclock @-> stackv4v6 @-> paf @-> mimic @-> mimic)
 
 let mimic_paf_impl time pclock stackv4v6 paf mimic_tcp =
   mimic_paf_conf ()
@@ -148,6 +95,7 @@ let mimic_paf_impl time pclock stackv4v6 paf mimic_tcp =
   $ stackv4v6
   $ paf
   $ mimic_tcp
+
 (* --- end of copied code --- *)
 
 let remote_k =
@@ -187,12 +135,11 @@ let dns_handler =
     package "dns-tsig";
     package ~min:"2.6.0" "irmin-mirage";
     package ~min:"2.6.0" "irmin-mirage-git";
-    package ~min:"3.4.0" "git-mirage";
     package "git-paf";
     package ~sublibs:["cohttp"] "paf";
   ] in
   foreign
-    ~keys:[Key.abstract remote_k ; Key.abstract axfr]
+    ~keys:[Key.v remote_k ; Key.v axfr]
     ~packages
     "Unikernel.Main"
     (random @-> pclock @-> mclock @-> time @-> stackv4v6 @-> mimic @-> job)


### PR DESCRIPTION
This PR is mostly a syntactic PR which upgrade the `config.ml` with the new version of `functoria` (which does not use objects anymore). As far as I can tell, targets work if we follow this document: https://next.mirage.io/wiki/mirage-4

However, I did not try to launch/deploy it yet.

PS: /cc @TheLortex, @mirage/core