### PR TITLE
Upgrade unikernel for MirageOS 4 & ocaml-git 3.8

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -4,152 +4,139 @@ open Mirage
 
 (* boilerplate from https://github.com/mirage/ocaml-git.git
    unikernel/empty-commit/config.ml
-   commit #45d90b8792ab8f3866751f462619c7dd7860e5d5 *)
+   commit #015b4400fb65488c12f988a167da52a104c2e603 *)
 type mimic = Mimic
 
 let mimic = typ Mimic
 
-let mimic_count =
-  let v = ref (-1) in
-  fun () -> incr v ; !v
-
-let mimic_conf () =
+let mimic_impl =
   let packages = [ package "mimic" ] in
-  impl @@ object
-       inherit base_configurable
-       method ty = mimic @-> mimic @-> mimic
-       method module_name = "Mimic.Merge"
-       method! packages = Key.pure packages
-       method name = Fmt.str "merge_ctx%02d" (mimic_count ())
-       method! connect _ _modname =
-         function
-         | [ a; b ] -> Fmt.str "Lwt.return (Mimic.merge %s %s)" a b
-         | [ x ] -> Fmt.str "%s.ctx" x
-         | _ -> Fmt.str "Lwt.return Mimic.empty"
-     end
+  let connect _ _modname = function
+    | [ a; b ] -> Fmt.str "Lwt.return (Mimic.merge %s %s)" a b
+    | [ x ] -> Fmt.str "%s.ctx" x
+    | _ -> Fmt.str "Lwt.return Mimic.empty" in
+  impl ~packages ~connect "Mimic.Merge" (mimic @-> mimic @-> mimic)
 
-let merge ctx0 ctx1 = mimic_conf () $ ctx0 $ ctx1
+let merge ctx0 ctx1 = mimic_impl $ ctx0 $ ctx1
 
-(* TODO(dinosaure): [timeout] and [timer interval]. *)
-let mimic_happy_eyeballs =
-  let packages = [ package "git-mirage" ~sublibs:[ "happy-eyeballs" ] ] in
-  impl @@ object
-       inherit base_configurable
-       method ty = random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> mimic
-       method module_name = "Git_mirage_happy_eyeballs.Make"
-       method! packages = Key.pure packages
-       method name = "git_mirage_happy_eyeballs"
-       method! connect _ modname = function
-         | [ _random; _time; _mclock; _pclock; stackv4v6; ] ->
-           Fmt.str {ocaml|%s.connect %s|ocaml} modname stackv4v6
-         | _ -> assert false
-     end
+let git_happy_eyeballs =
+  let packages = [ package "git-mirage"
+                      ~sublibs:[ "happy-eyeballs" ]
+                      ~min:"3.8.0" ] in
+  let connect _ modname = function
+    | [ _random; _time; _mclock; _pclock; stackv4v6; ] ->
+      Fmt.str {ocaml|%s.connect %s|ocaml} modname stackv4v6
+    | _ -> assert false in
+  impl ~packages ~connect "Git_mirage_happy_eyeballs.Make"
+    (random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> mimic)
 
-let mimic_tcp =
-  let packages = [ package "git-mirage" ~sublibs:[ "tcp" ] ] in
-  impl @@ object
-       inherit base_configurable
-       method ty = tcpv4v6 @-> mimic @-> mimic
-       method module_name = "Git_mirage_tcp.Make"
-       method! packages = Key.pure packages
-       method name = "git_mirage_tcp"
-       method! connect _ modname = function
-         | [ _tcpv4v6; ctx ] ->
-           Fmt.str {ocaml|%s.connect %s|ocaml}
-             modname ctx
-         | _ -> assert false
-     end
+let git_tcp =
+  let packages = [ package "git-mirage"
+                      ~sublibs:[ "tcp" ]
+                      ~min:"3.8.0" ] in
+  let connect _ modname = function
+    | [ _tcpv4v6; ctx ] ->
+      Fmt.str {ocaml|%s.connect %s|ocaml} modname ctx
+    | _ -> assert false in
+  impl ~packages ~connect "Git_mirage_tcp.Make"
+    (tcpv4v6 @-> mimic @-> mimic)
 
-let mimic_ssh ?authenticator key =
-  let packages = [ package "git-mirage" ~sublibs:[ "ssh" ] ] in
-  impl @@ object
-       inherit base_configurable
-       method ty = mclock @-> tcpv4v6 @-> mimic @-> mimic
-       method! keys = match authenticator with
-         | Some authenticator -> [ Key.abstract key; Key.abstract authenticator ]
-         | None -> [ Key.abstract key ]
-       method module_name = "Git_mirage_ssh.Make"
-       method! packages = Key.pure packages
-       method name = "git_mirage_ssh"
-       method! connect _ modname = function
-         | [ _mclock; _tcpv4v6; ctx ] ->
-           ( match authenticator with
-           | None ->
-             Fmt.str {ocaml|%s.connect %s >>= %s.with_optionnal_key ~key:%a|ocaml}
-               modname ctx modname Key.serialize_call (Key.abstract key)
-           | Some authenticator ->
-             Fmt.str {ocaml|%s.connect %s >>= %s.with_optionnal_key ?authenticator:%a ~key:%a|ocaml}
-               modname ctx modname
-               Key.serialize_call (Key.abstract authenticator)
-               Key.serialize_call (Key.abstract key) )
-         | _ -> assert false
-     end
+let git_ssh ?authenticator key =
+  let packages = [ package "git-mirage"
+                      ~sublibs:[ "ssh" ]
+                      ~min:"3.8.0" ] in
+  let connect _ modname = function
+    | [ _mclock; _tcpv4v6; _time; ctx ] ->
+      ( match authenticator with
+      | None ->
+        Fmt.str {ocaml|%s.connect %s >>= %s.with_optionnal_key ~key:%a|ocaml}
+          modname ctx modname Key.serialize_call (Key.v key)
+      | Some authenticator ->
+        Fmt.str {ocaml|%s.connect %s >>= %s.with_optionnal_key ?authenticator:%a ~key:%a|ocaml}
+          modname ctx modname
+          Key.serialize_call (Key.v authenticator)
+          Key.serialize_call (Key.v key) )
+    | _ -> assert false in
+  let keys = match authenticator with
+    | Some authenticator -> [ Key.v key; Key.v authenticator ]
+    | None -> [ Key.v key ] in
+  impl ~packages ~connect ~keys "Git_mirage_ssh.Make"
+    (mclock @-> tcpv4v6 @-> time @-> mimic @-> mimic)
 
-let mimic_http ?tls_key_fingerprint ?tls_cert_fingerprint headers =
-  let packages = [ package "git-mirage" ~sublibs:[ "http" ] ] in
-  impl @@ object
-       inherit base_configurable
-       method ty = time @-> pclock @-> tcpv4v6 @-> mimic @-> mimic
-       method! keys = match tls_key_fingerprint, tls_cert_fingerprint with
-         | Some tls_key_fingerprint, None ->
-           let keys = match headers with Some headers -> [ Key.abstract headers ] | None -> [] in
-           [ Key.abstract tls_key_fingerprint ] @ keys
-         | None, Some tls_cert_fingerprint ->
-           let keys = match headers with Some headers -> [ Key.abstract headers ] | None -> [] in
-           [ Key.abstract tls_cert_fingerprint ] @ keys
-         | Some tls_key_fingerprint, Some tls_cert_fingerprint ->
-           let keys = match headers with Some headers -> [ Key.abstract headers ] | None -> [] in
-           [ Key.abstract tls_key_fingerprint; Key.abstract tls_cert_fingerprint ] @ keys
-         | None, None -> ( match headers with Some headers -> [ Key.abstract headers ] | None -> [] )
-       method module_name = "Git_mirage_http.Make"
-       method! packages = Key.pure packages
-       method name = "git_mirage_http"
-       method! connect _ modname = function
-         | [ _time; _pclock; _tcpv4v6; ctx; ] ->
-           let serialize_headers ppf = function
-             | None -> ()
-             | Some headers -> Fmt.pf ppf "?headers:%a" Key.serialize_call (Key.abstract headers) in
-           ( match tls_key_fingerprint, tls_cert_fingerprint with
-           | Some tls_key_fingerprint, None ->
-             Fmt.str {ocaml|%s.connect %s >>= %s.with_optional_tls_config_and_headers ?tls_key_fingerprint:%a%a|ocaml}
-               modname ctx modname
-               Key.serialize_call (Key.abstract tls_key_fingerprint)
-               Fmt.((const string " ") ++ serialize_headers) headers
-           | None, Some tls_cert_fingerprint ->
-             Fmt.str {ocaml|%s.connect %s >>= %s.with_optional_tls_config_and_headers ?tls_cert_fingerprint:%a%a|ocaml}
-               modname ctx modname
-               Key.serialize_call (Key.abstract tls_cert_fingerprint)
-               Fmt.((const string " ") ++ serialize_headers) headers
-           | None, None ->
-             Fmt.str {ocaml|%s.connect %s >>= %s.with_optional_tls_config_and_headers%a|ocaml}
-               modname ctx modname
-               Fmt.((const string " ") ++ serialize_headers) headers
-           | Some tls_key_fingerprint, Some tls_cert_fingerprint ->
-             Fmt.str {ocaml|%s.connect %s >>= %s.with_optional_tls_config_and_headers
-                              ?tls_key_fingerprint:%a ?tls_cert_fingerprint:%a%a|ocaml}
-               modname ctx modname
-               Key.serialize_call (Key.abstract tls_key_fingerprint)
-               Key.serialize_call (Key.abstract tls_cert_fingerprint)
-               Fmt.((const string " ") ++ serialize_headers) headers )
-         | _ -> assert false
-     end
+let git_http ?authenticator headers =
+  let packages = [ package "git-mirage"
+                      ~sublibs:[ "http" ]
+                      ~min:"3.8.0" ] in
+  let keys =
+    let keys = [] in
+    let keys = match headers with Some headers -> Key.v headers :: keys | None -> keys in
+    let keys = match authenticator with Some authenticator -> Key.v authenticator :: keys | None -> [] in
+    keys in
+  let connect _ modname = function
+    | [ _time; _pclock; _tcpv4v6; ctx; ] ->
+      let serialize_headers ppf = function
+        | None -> ()
+        | Some headers -> Fmt.pf ppf " ?headers:%a" Key.serialize_call (Key.v headers) in
+      let serialize_authenticator ppf = function
+        | None -> ()
+        | Some authenticator -> Fmt.pf ppf " ?authenticator:%a" Key.serialize_call (Key.v authenticator) in
+      Fmt.str {ocaml|%s.connect %s >>= fun ctx -> %s.with_optional_tls_config_and_headers%a%a ctx|ocaml}
+        modname ctx modname
+        serialize_authenticator authenticator
+        serialize_headers headers
+    | _ -> assert false in
+  impl ~packages ~connect ~keys "Git_mirage_http.Make"
+    (time @-> pclock @-> tcpv4v6 @-> mimic @-> mimic)
 
 let tcpv4v6_of_stackv4v6 =
-  impl @@ object
-       inherit base_configurable
-       method ty = stackv4v6 @-> tcpv4v6
-       method module_name = "Git_mirage_happy_eyeballs.TCPV4V6"
-       method! packages = Key.pure [ package "git-mirage" ~sublibs:[ "happy-eyeballs" ] ]
-       method name = "tcpv4v6"
-       method! connect _ modname = function
-         | [ stackv4v6 ] -> Fmt.str {ocaml|%s.connect %s|ocaml} modname stackv4v6
-         | _ -> assert false
-     end
+  let connect _ modname = function
+    | [ stackv4v6 ] -> Fmt.str {ocaml|%s.connect %s|ocaml} modname stackv4v6
+    | _ -> assert false in
+  impl ~connect "Git_mirage_happy_eyeballs.TCPV4V6"
+    (stackv4v6 @-> tcpv4v6)
+
+type hash = Hash
+
+let hash = typ Hash
+
+let sha1 = impl ~packages:[ package "digestif" ] "Digestif.SHA1" hash
+
+type git = Git
+
+let git = typ Git
+
+let git_impl path =
+  let packages = [ package "git" ~min:"3.8.0" ] in
+  let keys = match path with
+    | None -> []
+    | Some path -> [ Key.v path ] in
+  let connect _ modname _ = match path with
+    | None ->
+        Fmt.str
+          {ocaml|%s.v (Fpath.v ".") >>= function
+                  | Ok v -> Lwt.return v
+                  | Error err -> Fmt.failwith "%%a" %s.pp_error err|ocaml}
+          modname modname
+    | Some key ->
+        Fmt.str
+          {ocaml|( match Option.map Fpath.of_string %a with
+                  | Some (Ok path) -> %s.v path
+                  | Some (Error (`Msg err)) -> failwith err
+                  | None -> %s.v (Fpath.v ".") ) >>= function
+                  | Ok v -> Lwt.return v
+                  | Error err -> Fmt.failwith "%%a" %s.pp_error err|ocaml}
+          Key.serialize_call (Key.v key) modname modname modname in
+  impl ~packages ~keys ~connect "Git.Mem.Make" (hash @-> git)
+
 (* --- end of copied code --- *)
 
 let remote_k =
   let doc = Key.Arg.info ~doc:"Remote git repository." ["r"; "remote"] in
-  Key.(create "remote" Arg.(opt string "https://github.com/roburio/udns.git" doc))
+  Key.(create "remote" Arg.(opt string "https://github.com/mirage/ocaml-dns" doc))
+
+let branch =
+  let doc = Key.Arg.info ~doc:"Remote git repository branch." ["b"; "branch"] in
+  Key.(create "branch" Arg.(opt string "main" doc))
 
 let axfr =
   let doc = Key.Arg.info ~doc:"Allow unauthenticated zone transfer." ["axfr"] in
@@ -159,26 +146,22 @@ let ssh_key =
   let doc = Key.Arg.info ~doc:"Private ssh key (rsa:<seed> or ed25519:<b64-key>)." ["ssh-key"] in
   Key.(create "ssh-key" Arg.(opt (some string) None doc))
 
-let authenticator =
-  let doc = Key.Arg.info ~doc:"Authenticator." ["authenticator"] in
-  Key.(create "authenticator" Arg.(opt (some string) None doc))
+let ssh_authenticator =
+  let doc = Key.Arg.info ~doc:"SSH public key of the remote Git repository." [ "ssh-authenticator" ] in
+  Key.(create "ssh_authenticator" Arg.(opt (some string) None doc))
 
-let tls_key_fingerprint =
-  let doc = Key.Arg.info ~doc:"The fingerprint of the TLS key." [ "tls-key-fingerprint" ] in
-  Key.(create "tls_key_fingerprint" Arg.(opt (some string) None doc))
-
-let tls_cert_fingerprint =
-  let doc = Key.Arg.info ~doc:"The fingerprint of the TLS certificate." [ "tls-cert-fingerprint" ] in
-  Key.(create "tls_cert_fingerprint" Arg.(opt (some string) None doc))
+let https_authenticator =
+  let doc = Key.Arg.info ~doc:"SSH public key of the remote Git repository." [ "https-authenticator" ] in
+  Key.(create "https_authenticator" Arg.(opt (some string) None doc))
 
 let mimic_impl random stackv4v6 mclock pclock time =
   let tcpv4v6 = tcpv4v6_of_stackv4v6 $ stackv4v6 in
-  let mhappy_eyeballs = mimic_happy_eyeballs $ random $ time $ mclock $ pclock $ stackv4v6 in
-  let mtcp  = mimic_tcp
+  let mhappy_eyeballs = git_happy_eyeballs $ random $ time $ mclock $ pclock $ stackv4v6 in
+  let mtcp  = git_tcp
     $ tcpv4v6 $ mhappy_eyeballs in
-  let mssh  = mimic_ssh ~authenticator ssh_key
-    $ mclock $ tcpv4v6 $ mhappy_eyeballs in
-  let mhttp = mimic_http ~tls_key_fingerprint ~tls_cert_fingerprint None
+  let mssh  = git_ssh ~authenticator:ssh_authenticator ssh_key
+    $ mclock $ tcpv4v6 $ time $ mhappy_eyeballs in
+  let mhttp = git_http ~authenticator:https_authenticator None
     $ time $ pclock $ tcpv4v6 $ mhappy_eyeballs in
   merge mhttp (merge mtcp mssh)
 
@@ -195,12 +178,12 @@ let dns_handler =
     package "dns-tsig";
     package ~min:"2.10.0" "irmin-mirage";
     package ~min:"2.10.0" "irmin-mirage-git";
-    package ~min:"3.7.0" "git-mirage";
-    package ~min:"3.7.0" "git-paf";
+    package ~min:"3.8.0" "git-mirage" ~sublibs:["happy-eyeballs"; "tcp"; "ssh"; "tcp"];
+    package ~min:"3.8.0" "git-paf";
     package ~min:"0.0.8" ~sublibs:["mirage"] "paf";
   ] in
   foreign
-    ~keys:[Key.abstract remote_k ; Key.abstract axfr]
+    ~keys:[Key.v remote_k ; Key.v branch; Key.v axfr]
     ~packages
     "Unikernel.Main"
     (random @-> pclock @-> mclock @-> time @-> stackv4v6 @-> mimic @-> job)

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -4,14 +4,14 @@
 
 open Lwt.Infix
 
-module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4V6) (_ : sig end) = struct
+module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Tcpip.Stack.V4V6) (_ : sig end) = struct
 
   module Store = Irmin_mirage_git.Mem.KV(Irmin.Contents.String)
   module Sync = Irmin.Sync(Store)
 
   let connect_store ctx =
     let config = Irmin_mem.config () in
-    Store.Repo.v config >>= Store.master >|= fun repo ->
+    Store.Repo.v config >>= fun repo -> Store.of_branch repo (Key_gen.branch ()) >|= fun repo ->
     repo, Store.remote ~ctx (Key_gen.remote ())
 
   let pull_store repo upstream =


### PR DESCRIPTION
Hello,
I have created this pull request in the context of this [issue](https://github.com/mirage/mirage/issues/1281).
Indeed I have worked on upgrading the `dns-primary-git` unikernel so it would be able to work with MirageOS v4.0.0.

In order to do that I have proceeded to various changes:
- I have update the code in `config.ml` copied from `https://github.com/mirage/ocaml-git.git` (line 5 to 131), so it would be compatible with the latest version of ocaml-git, the 3.8.0.
- Because this latest version has [changed the expectations](https://github.com/mirage/ocaml-git/pull/555/files#diff-9bbbc040c9b798fd3d7ae6b8b984d136413abfb4382145a8debf65c0868b69b6) of `git_mirage_http`, I made sure that it was persecuted in the keys in the `config.ml`.
- `Key.abstract` was [deprecated in mirage 4](https://github.com/mirage/mirage/blob/8b16bcfb7a190ac2e01bd23fa9bd9357a0d03726/lib/mirage/mirage_key.mli#L35), I update it to `Key.v`
- The remote repository by default was linked to https://github.com/roburio/udns.git, however it is advertised there that the official implementation has moved to https://github.com/mirage/ocaml-git.git and is therefore deprecated, I changed that as well
- The latest modification induced a problem, the new repository has changed it's main branch from `master` to `main`, which was incompatible with the current code (`master` was always the branch asked for). I added a key in order to allow other branches to be pulled, and set it to `main` by default (it suppose it would be the most appropriate choice).

I am a bit new to `dns-primary-git`, so you might want to check if it works on your side on a real workflow, but it should normally work as intended.

I am obviously available for your remarks or changes requests.